### PR TITLE
Add production sync workflow and helper script

### DIFF
--- a/.github/workflows/sync-prod.yml
+++ b/.github/workflows/sync-prod.yml
@@ -1,0 +1,48 @@
+name: Sync prod branch
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "prod-sync-bot"
+          git config user.email "prod-sync-bot@users.noreply.github.com"
+
+      - name: Sync prod from main subset
+        env:
+          KEEP: "build"    # space-separated list if you add more
+        run: |
+          git fetch origin
+
+          # Use the existing prod branch; don't recreate it
+          git checkout prod 2>/dev/null || git checkout -b prod origin/prod
+
+          # Replace each kept directory with main's current contents
+          for d in $KEEP; do
+            git rm -rf -- "$d" 2>/dev/null || true
+            git checkout origin/main -- "$d"
+          done
+
+          # Defensive: remove anything outside KEEP
+          PATTERN="^($(echo $KEEP | tr ' ' '|'))/"
+          git ls-files -z | grep -zvE "$PATTERN" | xargs -0 -r git rm -f
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "prod already up to date."
+          else
+            git commit -m "Sync prod from main @ ${GITHUB_SHA::7}"
+            git push origin prod
+          fi

--- a/.github/workflows/sync-prod.yml
+++ b/.github/workflows/sync-prod.yml
@@ -24,25 +24,43 @@ jobs:
         env:
           KEEP: "build"    # space-separated list if you add more
         run: |
+          set -euo pipefail
           git fetch origin
 
           # Use the existing prod branch; don't recreate it
           git checkout prod 2>/dev/null || git checkout -b prod origin/prod
+          git reset --hard origin/prod
+
+          # Use the triggering commit on push, otherwise latest main for manual runs
+          SOURCE_REF="${GITHUB_SHA:-origin/main}"
+
+          IFS=' ' read -r -a keep_dirs <<< "$KEEP"
+          if [ "${#keep_dirs[@]}" -eq 0 ] || [ -z "$(printf '%s' "$KEEP" | tr -d '[:space:]')" ]; then
+            echo "KEEP must contain at least one directory" >&2
+            exit 1
+          fi
 
           # Replace each kept directory with main's current contents
-          for d in $KEEP; do
+          for d in "${keep_dirs[@]}"; do
             git rm -rf -- "$d" 2>/dev/null || true
-            git checkout origin/main -- "$d"
+            git checkout "$SOURCE_REF" -- "$d"
           done
 
           # Defensive: remove anything outside KEEP
-          PATTERN="^($(echo $KEEP | tr ' ' '|'))/"
+          pattern_parts=()
+          for d in "${keep_dirs[@]}"; do
+            escaped_d=$(printf '%s\n' "$d" | sed 's/[][(){}.^$*+?|\\]/\\&/g')
+            pattern_parts+=("$escaped_d")
+          done
+          PATTERN="^($(IFS='|'; echo "${pattern_parts[*]}"))/"
           git ls-files -z | grep -zvE "$PATTERN" | xargs -0 -r git rm -f
 
           git add -A
           if git diff --cached --quiet; then
             echo "prod already up to date."
           else
-            git commit -m "Sync prod from main @ ${GITHUB_SHA::7}"
+            source_short_sha=$(git rev-parse --short "$SOURCE_REF")
+            git commit -m "Sync prod from main @ ${source_short_sha}"
             git push origin prod
+          fi
           fi

--- a/scripts/sync-prod.sh
+++ b/scripts/sync-prod.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directories to keep on prod — edit this list
+KEEP=(build)
+
+git fetch origin
+
+# Switch to the existing prod branch (create local tracking if needed)
+git checkout prod 2>/dev/null || git checkout -b prod origin/prod
+git pull --ff-only origin prod
+
+# Replace each kept directory with whatever main has now
+for d in "${KEEP[@]}"; do
+  git rm -rf -- "$d" 2>/dev/null || true
+  git checkout origin/main -- "$d"
+done
+
+# Defensive sweep: drop anything that somehow ended up outside KEEP
+PATTERN="^($(IFS='|'; echo "${KEEP[*]}"))/"
+git ls-files -z | grep -zvE "$PATTERN" | xargs -0 -r git rm -f
+
+git add -A
+if git diff --cached --quiet; then
+  echo "prod already up to date with main."
+else
+  git commit -m "Sync prod from main @ $(git rev-parse --short origin/main)"
+  git push origin prod
+fi

--- a/scripts/sync-prod.sh
+++ b/scripts/sync-prod.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Directories to keep on prod — edit this list
 KEEP=(build)
 
+if [[ "${#KEEP[@]}" -eq 0 ]]; then
+  echo "KEEP must contain at least one directory." >&2
+  exit 1
+fi
+
 git fetch origin
 
 # Switch to the existing prod branch (create local tracking if needed)
@@ -17,7 +22,12 @@ for d in "${KEEP[@]}"; do
 done
 
 # Defensive sweep: drop anything that somehow ended up outside KEEP
-PATTERN="^($(IFS='|'; echo "${KEEP[*]}"))/"
+ESCAPED_KEEP=()
+for d in "${KEEP[@]}"; do
+  escaped_d=$(printf '%s' "$d" | sed 's/[][(){}.^$*+?|\\]/\\&/g')
+  ESCAPED_KEEP+=("$escaped_d")
+done
+PATTERN="^($(IFS='|'; echo "${ESCAPED_KEEP[*]}"))/"
 git ls-files -z | grep -zvE "$PATTERN" | xargs -0 -r git rm -f
 
 git add -A


### PR DESCRIPTION
## Summary
Add automation for keeping the `prod` branch synced from `main` in a controlled way.

## Changes
- Add GitHub Actions workflow: `.github/workflows/sync-prod.yml`
- Add helper script: `scripts/sync-prod.sh`

## Why
This isolates production branch sync logic so `prod` can be updated from `main` consistently and repeatably, while day-to-day development remains on feature branches and `main`.